### PR TITLE
 feat: client create helper and enable editing generated file

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -238,6 +238,7 @@ where
 
         let mut buf = vec![];
 
+        writeln!(buf, "\nimport * as rspc from '@rspc/client'")?;
 
         let mut dependencies = BTreeSet::<TSDependency>::new();
 
@@ -278,6 +279,37 @@ where
         write!(buf, "\nexport type Subscriptions =")?;
         buf.write_all(&subscription_buf)?;
         writeln!(buf, ";")?;
+
+        writeln!(
+            buf,
+            "\nexport type TransportKind = \"fetch\" | \"websocket\";"
+        )?;
+
+        writeln!(
+            buf,
+            "\n\n{}",
+            vec![
+                "/** create new rspc client with address and kind",
+                " * @param {string} address - rspc enspoint address",
+                " * @param {TransportKind} kind - {@link TransportKind} to use",
+                " * */"
+            ]
+            .join("\n")
+        )?;
+        writeln!(
+            buf,
+            "{}",
+            vec![
+                "export const createClient = (kind: TransportKind, address: string) =>",
+                "  rspc.createClient<Operations>({",
+                "    transport:",
+                "      kind === \"fetch\"",
+                "        ? new rspc.FetchTransport(address)",
+                "        : new rspc.WebsocketTransport(address)",
+                "  });"
+            ]
+            .join("\n")
+        )?;
 
         if let Some(marker) = begin_marker {
             lines.insert(marker, header);


### PR DESCRIPTION
# feat: client create helper and enable editing generated file

In my project, I've create a new file to hold my client connection, but felt it was redundant, and I figured it might be simpler and consistent if everything can be in rspc's generated file. Therefore, this PR:

- Enables rspc users to edit the generated rspsc file to add thier own code (either after/before generated setion).
- Introduce createClient function and TransportKind type to simplify rspc setup.

### Before

~~~ts
import { createClient, FetchTransport } from '@rspc/client'
import { Operations } from 'rspc'
const client = createClient<Operations>({
  transport: new FetchTransport('http://localhost:4000/rspc'),
})
~~~

### After

~~~ts
import { createClient } from 'rspc'
export const client = createClient('fetch', 'http://localhost:4000/rspc')
~~~

