### PR TITLE
Update URL for specta

### DIFF
--- a/docs/markdown/server/specta.md
+++ b/docs/markdown/server/specta.md
@@ -2,7 +2,7 @@
 title: Specta
 ---
 
-For rspc to be able to convert your types into Typescript they must implement the `specta::Type` trait. [Specta](https://github.com/oscartbeaumont/rspc/tree/main/specta) is a crate that was created so that rspc can introspect Rust types. The `Type` trait allows the Typescript exporter to understand the fields, generics and dependant types of a Rust type.
+For rspc to be able to convert your types into Typescript they must implement the `specta::Type` trait. [Specta](https://github.com/oscartbeaumont/specta) is a crate that was created so that rspc can introspect Rust types. The `Type` trait allows the Typescript exporter to understand the fields, generics and dependant types of a Rust type.
 
 The easiest way to implement the `specta::Type` trait is by using the `rspc::Type` derive macro. We have already implemented most in-built types if you can find a missing one open a [GitHub Issue](https://github.com/oscartbeaumont/rspc).
 


### PR DESCRIPTION
This patch updates the URL for specta, which I found to be 404 while exploring the website.