### PR TITLE
deps: use `tempfile` instead of `tempdir`

### DIFF
--- a/create-rspc-app/Cargo.toml
+++ b/create-rspc-app/Cargo.toml
@@ -23,8 +23,10 @@ thiserror = "1.0.38"
 walkdir = "2"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.4.0"
 cargo = "0.67.1"
 tokio = { version = "1.25.0", features = ["full", "process"] }
-ssh2 = { version = "0.9.3", features = ["vendored-openssl"] } # This is need for M1 support
+ssh2 = { version = "0.9.3", features = [
+    "vendored-openssl",
+] } # This is need for M1 support
 futures = "0.3.26"

--- a/create-rspc-app/tests/tests.rs
+++ b/create-rspc-app/tests/tests.rs
@@ -17,7 +17,7 @@ use create_rspc_app::internal::{
 };
 use futures::future::join_all;
 use strum::IntoEnumIterator;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio::process::Command;
 
 #[tokio::test]
@@ -28,7 +28,7 @@ async fn test_templates() {
     );
     env::set_var("CARGO_TERM_VERBOSE", "false");
     env::set_var("CARGO_QUITE", "true");
-    let dir = TempDir::new("create_rspc_app_test").unwrap();
+    let dir = TempDir::new().unwrap();
     let result = _test(dir.path()).await;
     env::remove_var("CARGO_TARGET_DIR");
     remove_dir_all(&dir).unwrap();
@@ -143,7 +143,7 @@ async fn _test(base_dir: &Path) -> Result<(), String> {
                             )
                         })?;
                     compile_cfg.spec = Packages::Packages(vec!["rspc-test".into()]);
-                    if let Err(err) = cargo::ops::compile(&ws, &compile_cfg) {
+                    if let Err(err) = cargo::ops::compile(ws, &compile_cfg) {
                         return Err(format!(
                             "Error({:?}-{:?}-{:?}): Failed to compile: {}",
                             framework, database, frontend, err


### PR DESCRIPTION
The `tempdir` crate has been unmaintained for years, and it's using a vulnerable version of `remove_dir_all` ([source](https://rustsec.org/advisories/RUSTSEC-2023-0018.html)).

This PR replaces `tempdir` with `tempfile`, which means that `cargo audit` is a little happier. There's still `time v0.1.45` in the tree, but that's due to [chrono](https://github.com/chronotope/chrono/issues/602) and there's not much we can do there aside from wait for a new release (unless we completely drop support for it).