### PR TITLE
fix: Update httpz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rspc"
 description = "A blazing fast and easy to use TRPC server for Rust."
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
 edition = "2021"
 license = "MIT"
@@ -43,7 +43,7 @@ bson = ["specta/bson"]
 
 [dependencies]
 specta = { version = "1.0.0", features = ["serde", "typescript"] }
-httpz = { version = "0.0.4", optional = true } # TODO: Move back to crates.io release
+httpz = { version = "0.0.6", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 thiserror = "1.0.38"


### PR DESCRIPTION
Depends on:
- https://github.com/oscartbeaumont/httpz/pull/37

Note: this branch just so happened to exist. But I would recommend a `v0.x` branch instead from the `v0.1.3` tag.