### PR TITLE
docs: fix `rspc-tauri` crate name

### DIFF
--- a/docs/pages/integrations/tauri.mdx
+++ b/docs/pages/integrations/tauri.mdx
@@ -13,7 +13,7 @@ For the integration to work you must enable the `tauri` feature of rspc. Ensure 
 ```toml /rspc_tauri = "0.0.0"/ copy filename="Cargo.toml"
 [dependencies]
 rspc = "0.0.0"
-rspc_tauri = "0.0.0"
+rspc-tauri = "0.0.0"
 ```
 
 Read more about Rust features [here](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features)


### PR DESCRIPTION
`rspc_tauri` -> `rspc-tauri`