### PR TITLE
fix(@rspc/react): make sure type-only export gets stripped from .mjs files

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -37,7 +37,7 @@ import {
 	useEffect,
 } from "react";
 
-export { BaseOptions } from "@rspc/query-core";
+export type { BaseOptions } from "@rspc/query-core";
 
 export interface SubscriptionOptions<TOutput> {
 	enabled?: boolean;


### PR DESCRIPTION
I haven't tested this but it should fix the issue

fix #291