### PR TITLE
fix axum 0.8 path

### DIFF
--- a/integrations/axum/src/v2.rs
+++ b/integrations/axum/src/v2.rs
@@ -30,7 +30,7 @@ where
     let procedures = procedures.borrow().clone();
 
     Router::<S>::new().route(
-        "/:id",
+        "/{id}",
         on(
             MethodFilter::GET.or(MethodFilter::POST),
             move |state: State<S>, req: axum::extract::Request<Body>| {


### PR DESCRIPTION
The path parameter syntax changed in axum 0.8, causing panic in current axum integrations (https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0).
This PR fixes it.